### PR TITLE
Allow using relative links from the file to preview, references  #11

### DIFF
--- a/markdown-preview-mode.el
+++ b/markdown-preview-mode.el
@@ -74,7 +74,12 @@
 
 (defun markdown-preview--open-browser-preview ()
   "Open the markdown preview in the browser."
-  (browse-url markdown-preview--preview-url))
+  (let* ((dir-of-buffer-to-preview (file-name-directory
+                                    (buffer-file-name (get-buffer (buffer-name)))))
+         (preview-file (concat dir-of-buffer-to-preview ".markdown-preview.html")))
+    (if (not (file-exists-p preview-file))
+        (copy-file markdown-preview--preview-url preview-file))
+    (browse-url preview-file)))
 
 (defun markdown-preview--stop-websocket-server ()
   "Stop the `markdown-preview' websocket server."


### PR DESCRIPTION
Change the implementation of "markdown-preview--open-browser-preview" to
copy "preview.html" into the directory of the Markdown file to be
previewed and browse-url that file instead.
