### PR TITLE
Default to 'local for markdown-preview-host

### DIFF
--- a/markdown-preview-mode.el
+++ b/markdown-preview-mode.el
@@ -40,10 +40,11 @@
   :prefix "markdown-preview-"
   :link '(url-link "https://github.com/ancane/markdown-preview-mode"))
 
-(defcustom markdown-preview-host "127.0.0.1"
+(defcustom markdown-preview-host 'local
   "Markdown preview websocket server address."
   :group 'markdown-preview
-  :type 'string)
+  :type '(choice (const :tag "localhost" local)
+                 (string :tag "Custom host")))
 
 (defcustom markdown-preview-port 7379
   "Markdown preview websocket server port."


### PR DESCRIPTION
- Prefer to use `'local` over `"127.0.0.1"` to indicate localhost, as the underlying functions use 'local for localhost.
- Adjust type to be a union of `'local` and a string.

As mentioned in https://github.com/ancane/markdown-preview-mode/issues/10, this is a slight improvement over just a string.
