### PR TITLE
Add inline css/js support

### DIFF
--- a/markdown-preview-mode.el
+++ b/markdown-preview-mode.el
@@ -115,14 +115,16 @@
   (when (timerp markdown-preview--idle-timer)
     (cancel-timer markdown-preview--idle-timer)))
 
-(defun markdown-preview--css-links ()
+(defun markdown-preview--css ()
   "Get list of styles for preview in backward compatible way."
   (let* ((custom-style (list markdown-preview-style))
          (all-styles
           (mapc (lambda (x) (add-to-list 'custom-style x t)) markdown-preview-stylesheets)))
     (mapconcat
      (lambda (x)
-       (concat "<link rel=\"stylesheet\" type=\"text/css\" href=\"" x "\">"))
+       (if (string-match-p "^[\n\t ]*<style" x)
+           x
+         (concat "<link rel=\"stylesheet\" type=\"text/css\" href=\"" x "\">")))
      all-styles
      "\n")))
 
@@ -130,10 +132,12 @@
   "Get list of javascript script tags for preview."
   (mapconcat
    (lambda (x)
-     (concat
-      "<script src=\"" (if (consp x) (car x) x) "\""
-      (if (consp x) (format " %s" (cdr x)))
-      "></script>"))
+     (if (string-match-p "^[\n\t ]*<script" x)
+         x
+       (concat
+        "<script src=\"" (if (consp x) (car x) x) "\""
+        (if (consp x) (format " %s" (cdr x)))
+        "></script>")))
    markdown-preview-javascript
    "\n"))
 
@@ -143,7 +147,7 @@ rendered copy to PREVIEW-FILE, ready to be open in browser."
   (with-temp-file preview-file
     (insert-file-contents (expand-file-name "preview.html" markdown-preview--home-dir))
     (when (search-forward "${MD_STYLE}" nil t)
-        (replace-match (markdown-preview--css-links) t))
+        (replace-match (markdown-preview--css) t))
     (when (search-forward "${MD_JS}" nil t)
         (replace-match (markdown-preview--scripts) t))
     (when (search-forward "${WS_HOST}" nil t)

--- a/preview.html
+++ b/preview.html
@@ -23,7 +23,7 @@
              console.log('Code: ' + event.code + ' reason: ' + event.reason);
          };
          socket.onmessage = function(event) {
-             $("#markdown-body").html($(event.data).find("#content").html());
+             $("#markdown-body").html($(event.data).find("#content").html()).trigger('mdContentChange');
              var scroll = $(document).height() * ($(event.data).find("#position-percentage").html() / 100);
              $("html, body").animate({ scrollTop: scroll }, 600);
          };


### PR DESCRIPTION
Inline css/js will be handy sometimes, e.g. to apply [github-markdown-css](https://github.com/sindresorhus/github-markdown-css) and [highlight.js](https://github.com/isagalaev/highlight.js):
```lisp
(setq markdown-preview-stylesheets
      (list "https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.9.0/github-markdown.min.css"
            "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css" "
  <style>
   .markdown-body {
     box-sizing: border-box;
     min-width: 200px;
     max-width: 980px;
     margin: 0 auto;
     padding: 45px;
   }

   @media (max-width: 767px) {
     .markdown-body {
       padding: 15px;
     }
   }
  </style>
"))
(setq markdown-preview-javascript
      (list "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js" "
  <script>
   $(document).on('mdContentChange', function() {
     $('pre code').each(function(i, block) {
       hljs.highlightBlock(block);
     });
   });
  </script>
"))
```