### PR TITLE
Allow injection of javascript evaluated on init/update

### DIFF
--- a/markdown-preview-mode.el
+++ b/markdown-preview-mode.el
@@ -84,6 +84,16 @@
   :group 'markdown-preview
   :type 'float)
 
+(defcustom markdown-preview-script-oninit ""
+  "Markdown preview javascript which runs on init."
+  :group 'markdown-preview
+  :type 'string)
+
+(defcustom markdown-preview-script-onupdate ""
+  "Markdown preview javascript which runs on update preview."
+  :group 'markdown-preview
+  :type 'string)
+
 (defvar markdown-preview-javascript '()
   "List of client javascript libs for preview.")
 
@@ -158,12 +168,16 @@
       (replace-match (markdown-preview--css) t))
     (when (search-forward "${MD_JS}" nil t)
       (replace-match (markdown-preview--scripts) t))
+    (when (search-forward "${MD_JS_ONINIT}" nil t)
+      (replace-match markdown-preview-script-oninit t))
     (when (search-forward "${WS_HOST}" nil t)
       (replace-match markdown-preview-host t))
     (when (search-forward "${WS_PORT}" nil t)
       (replace-match (format "%s" markdown-preview-ws-port) t))
     (when (search-forward "${MD_UUID}" nil t)
       (replace-match (format "%s" preview-uuid) t))
+    (when (search-forward "${MD_JS_ONUPDATE}" nil t)
+      (replace-match markdown-preview-script-onupdate t))
     (buffer-string)))
 
 ;; Emacs 26 async network workaround

--- a/preview.html
+++ b/preview.html
@@ -8,6 +8,7 @@
     <script src="http://code.jquery.com/jquery-1.12.4.min.js"></script>
     ${MD_JS}
     <script>
+     ${MD_JS_ONINIT}
      (function($, undefined) {
          var socket = new WebSocket("ws://${WS_HOST}:${WS_PORT}");
          socket.onopen = function() {
@@ -26,6 +27,7 @@
              $("#markdown-body").html($(event.data).find("#content").html()).trigger('mdContentChange');
              var scroll = $(document).height() * ($(event.data).find("#position-percentage").html() / 100);
              $("html, body").animate({ scrollTop: scroll }, 600);
+             ${MD_JS_ONUPDATE}
          };
          socket.onerror = function(error) {
              console.log("Error: " + error.message);

--- a/preview.html
+++ b/preview.html
@@ -13,7 +13,7 @@
          var socket = new WebSocket("ws://${WS_HOST}:${WS_PORT}");
          socket.onopen = function() {
              console.log("Connection established.");
-	     socket.send("MDPM-Register-UUID: ${MD_UUID}");
+             socket.send("MDPM-Register-UUID: ${MD_UUID}");
          };
          socket.onclose = function(event) {
              if (event.wasClean) {


### PR DESCRIPTION
Example: using [mermaid.js](https://mermaid-js.github.io/mermaid/#/)

init.el:
```lisp
(setq markdown-command "pandoc -f gfm")
(setq markdown-preview-javascript
    (list "https://cdnjs.cloudflare.com/ajax/libs/mermaid/9.1.7/mermaid.min.js"))
(setq markdown-preview-script-oninit 
    "mermaid.initialize({startOnLoad:false});")
(setq markdown-preview-script-onupdate
    "$('pre.mermaid').each(function(_,e){$(e).html($(e,'code').text())}); mermaid.init();"))
```